### PR TITLE
Fix multithreading issues in synchronized_queue

### DIFF
--- a/src/synchronized_queue.hpp
+++ b/src/synchronized_queue.hpp
@@ -97,11 +97,11 @@ class synchronized_queue {
   std::queue<T> m_data;          ///< Internal queue
   std::mutex m_mutex;            ///< Internal mutex
   std::condition_variable m_cv;  ///< Internal condition variable
-  std::atomic_bool m_closed;     ///< Keeps state of
+  bool m_closed;                 ///< Is queue closed
 };
 
 template <typename T>
-synchronized_queue<T>::synchronized_queue() : m_data(), m_closed(ATOMIC_VAR_INIT(false)) {}
+synchronized_queue<T>::synchronized_queue() : m_data(), m_closed(false) {}
 
 template <typename T>
 synchronized_queue<T>::~synchronized_queue() {
@@ -144,8 +144,9 @@ bool synchronized_queue<T>::closed() const {
 
 template <typename T>
 void synchronized_queue<T>::close() {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_closed = true;
-  m_cv.notify_one();
+  m_cv.notify_all();
 }
 
 template <typename T>


### PR DESCRIPTION
There was a race condition between waiting for m_cv and notifying it.
m_cv was also notifying just one thread instead of all, which caused
deadlocks. m_closed doesn't need to be atomic.